### PR TITLE
Add debugger2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,13 +13,11 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     builder (3.2.2)
-    columnize (0.8.9)
-    debugger (1.6.8)
+    columnize (0.9.0)
+    debugger-linecache (1.2.0)
+    debugger2 (1.0.0.beta2)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     gyoku (1.1.1)
       builder (>= 2.1.2)
     httpi (2.1.1)
@@ -51,7 +49,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  debugger
+  debugger2
   minitest
   nfe-paulistana!
   rake

--- a/nfe-paulistana.gemspec
+++ b/nfe-paulistana.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "signer"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"
-  s.add_development_dependency "debugger"
+  s.add_development_dependency "debugger2"
   # s.add_runtime_dependency "rest-client"
 end


### PR DESCRIPTION
Debugger1 only works on ruby 1.9.2 and 1.9.3 and was replaced by debugger2
that also support MRI 2
